### PR TITLE
Add basic support for CDATA tags in items

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Creating items with complex tags:
                   :category [{:domain "http://www.foo.com/bar"} "BAZ"]})
 ```
 
+Items can contain raw HTML if the tag is enclosed in `<![CDATA[ ... ]]>`:
+```clojure
+  {:title "HTML Item" 
+   :description "<![CDATA[ <h1><a href='http://foo/bar'>Foo</a></h1> ]]>"}
+```
+
 To get the raw data structure use:
 ```clojure
 (rss/channel {:title "Foo" :link "http://foo/bar" :description "some channel"}

--- a/src/clj_rss/core.clj
+++ b/src/clj_rss/core.clj
@@ -8,13 +8,19 @@
   (when t
     (.format (new SimpleDateFormat "EEE, dd MMM yyyy HH:mm:ss ZZZZ") t)))
 
-(defn- xml-str [s]
-  (if s
-    (let [escapes {\< "&lt;",
-                   \> "&gt;",
-                   \& "&amp;",
-                   \" "&quot;"}]
-      (escape s escapes))))
+(defn- xml-str
+  "Returns a string suitable for inclusion as an XML element. If the string
+  is wrapped in <![CDATA[ ... ]]>, do not escape special characters."
+  [^String s]
+  (if (and (.startsWith s "<![CDATA[")
+           (.endsWith s "]]>"))
+    s
+    (if s
+      (let [escapes {\< "&lt;",
+                     \> "&gt;",
+                     \& "&amp;",
+                     \" "&quot;"}]
+        (escape s escapes)))))
 
 (defmacro tag [id & xs]
   `(let [attrs# (map? (first '~xs))

--- a/test/clj_rss/core_test.clj
+++ b/test/clj_rss/core_test.clj
@@ -58,6 +58,11 @@
                   {:title "test"
                    :category [{:domain "http://www.fool.com/cusips"} "MSFT"]}))))
 
+(deftest cdata-tag
+  (is (= "<?xml version='1.0' encoding='UTF-8'?>\n<rss version='2.0' xmlns:atom='http://www.w3.org/2005/Atom'>\n<channel>\n<atom:link href='http://foo/bar' rel='self' type='application/rss+xml'/>\n<generator>\nclj-rss\n</generator>\n<description>\nsome channel\n</description>\n<title>\nFoo\n</title>\n<link>\nhttp://foo/bar\n</link>\n<item>\n<description>\n<![CDATA[ <h1><a href='http://foo/bar'>Foo</a></h1> ]]>\n</description>\n<title>\nHTML Item\n</title>\n</item>\n</channel>\n</rss>\n"
+         (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel"}
+                           {:title "HTML Item" :description "<![CDATA[ <h1><a href='http://foo/bar'>Foo</a></h1> ]]>"}))))
+
 (deftest validation-on
   (is
     (thrown? Exception


### PR DESCRIPTION
Mostly involves skipping the escaping process when a tag is wrapped in `<![CDATA[ ]]>`. 

Includes tests and docs. The output XML passes the [WC3 Feed Validation Service](http://validator.w3.org/feed/check.cgi).
