### PR TITLE
Do XML escapes for :link tag

### DIFF
--- a/src/clj_rss/core.clj
+++ b/src/clj_rss/core.clj
@@ -85,7 +85,7 @@
      :else
      (tag k (cond
              (some #{k} [:pubDate :lastBuildDate]) (format-time v)
-             (some #{k} [:description :title]) (xml-str v)
+             (some #{k} [:description :title :link]) (xml-str v)
              :else v))))))
 
 


### PR DESCRIPTION
Ran into this when making RSS for material that had `&` -characters in the URL, like `http://www.somenewssite.com/news.asp?CAT=1-1&ID=295819`