### PR TITLE
Remove superflous newline characters

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,6 @@
   :url "https://github.com/yogthos/clj-rss"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]]
+  :dependencies [[org.clojure/clojure "1.10.0"]]
   :profiles {:dev
              {:dependencies [[hickory "0.6.0"]]}})

--- a/project.clj
+++ b/project.clj
@@ -3,6 +3,7 @@
   :url "https://github.com/yogthos/clj-rss"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.0"]]
+  :dependencies [[org.clojure/clojure "1.10.0"]
+                 [org.clojure/data.xml "0.2.0-alpha6"]]
   :profiles {:dev
              {:dependencies [[hickory "0.6.0"]]}})

--- a/src/clj_rss/core.clj
+++ b/src/clj_rss/core.clj
@@ -1,6 +1,5 @@
 (ns clj-rss.core
-  (:use [clojure.xml :only [emit]]
-        [clojure.set :only [difference]]
+  (:use [clojure.set :only [difference]]
         [clojure.string :only [escape join]])
   (:import java.util.Date java.util.Locale java.text.SimpleDateFormat))
 
@@ -144,6 +143,26 @@
     (apply channel' (cons true content))
     :else
     (apply channel' content)))
+
+(defn- emit-element [e]
+  (if (instance? String e)
+    (print e)
+    (do
+      (print (str "<" (name (:tag e))))
+      (when (:attrs e)
+	(doseq [attr (:attrs e)]
+	  (print (str " " (name (key attr)) "='" (val attr)"'"))))
+      (if (:content e)
+	(do
+	  (print ">")
+	  (doseq [c (:content e)]
+	    (emit-element c))
+	  (print (str "</" (name (:tag e)) ">")))
+	(print "/>")))))
+
+(defn- emit [x]
+  (print "<?xml version='1.0' encoding='UTF-8'?>")
+  (emit-element x))
 
 (defn channel-xml
   "channel accepts a map of tags followed by 0 or more items and outputs an XML string, see channel docs for detailed description"

--- a/test/clj_rss/core_test.clj
+++ b/test/clj_rss/core_test.clj
@@ -5,7 +5,7 @@
 
 (deftest proper-message
   (is
-   (= "<?xml version='1.0' encoding='UTF-8'?>\n<rss version='2.0' xmlns:atom='http://www.w3.org/2005/Atom'>\n<channel>\n<atom:link href='http://foo/bar' rel='self' type='application/rss+xml'/>\n<title>\nFoo\n</title>\n<link>\nhttp://foo/bar\n</link>\n<description>\nsome channel\n</description>\n<generator>\nclj-rss\n</generator>\n<item>\n<title>\nFoo\n</title>\n</item>\n<item>\n<title>\npost\n</title>\n<author>\nYogthos\n</author>\n</item>\n<item>\n<description>\nbar\n</description>\n</item>\n</channel>\n</rss>\n"
+   (= "<?xml version='1.0' encoding='UTF-8'?><rss version='2.0' xmlns:atom='http://www.w3.org/2005/Atom'><channel><atom:link href='http://foo/bar' rel='self' type='application/rss+xml'/><title>Foo</title><link>http://foo/bar</link><description>some channel</description><generator>clj-rss</generator><item><title>Foo</title></item><item><title>post</title><author>Yogthos</author></item><item><description>bar</description></item></channel></rss>"
       (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel"}
                    {:title "Foo"}
                    {:title "post" :author "Yogthos"}
@@ -46,13 +46,13 @@
                          {:link "http://foo"}))))
 
 (deftest complex-tag
-  (is (= "<?xml version='1.0' encoding='UTF-8'?>\n<rss version='2.0' xmlns:atom='http://www.w3.org/2005/Atom'>\n<channel>\n<atom:link href='http://foo/bar' rel='self' type='application/rss+xml'/>\n<title>\nFoo\n</title>\n<link>\nhttp://foo/bar\n</link>\n<description>\nsome channel\n</description>\n<generator>\nclj-rss\n</generator>\n<item>\n<title>\ntest\n</title>\n<category domain='http://www.fool.com/cusips'>\nMSFT\n</category>\n</item>\n</channel>\n</rss>\n"
+  (is (= "<?xml version='1.0' encoding='UTF-8'?><rss version='2.0' xmlns:atom='http://www.w3.org/2005/Atom'><channel><atom:link href='http://foo/bar' rel='self' type='application/rss+xml'/><title>Foo</title><link>http://foo/bar</link><description>some channel</description><generator>clj-rss</generator><item><title>test</title><category domain='http://www.fool.com/cusips'>MSFT</category></item></channel></rss>"
          (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel"}
                       {:title "test"
                        :category [{:domain "http://www.fool.com/cusips"} "MSFT"]}))))
 
 (deftest cdata-tag
-  (is (= "<?xml version='1.0' encoding='UTF-8'?>\n<rss version='2.0' xmlns:atom='http://www.w3.org/2005/Atom'>\n<channel>\n<atom:link href='http://foo/bar' rel='self' type='application/rss+xml'/>\n<title>\nFoo\n</title>\n<link>\nhttp://foo/bar\n</link>\n<description>\nsome channel\n</description>\n<generator>\nclj-rss\n</generator>\n<item>\n<title>\nHTML Item\n</title>\n<description>\n<![CDATA[ <h1><a href='http://foo/bar'>Foo</a></h1> ]]>\n</description>\n</item>\n</channel>\n</rss>\n"
+  (is (= "<?xml version='1.0' encoding='UTF-8'?><rss version='2.0' xmlns:atom='http://www.w3.org/2005/Atom'><channel><atom:link href='http://foo/bar' rel='self' type='application/rss+xml'/><title>Foo</title><link>http://foo/bar</link><description>some channel</description><generator>clj-rss</generator><item><title>HTML Item</title><description><![CDATA[ <h1><a href='http://foo/bar'>Foo</a></h1> ]]></description></item></channel></rss>"
          (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel"}
                       {:title "HTML Item" :description "<![CDATA[ <h1><a href='http://foo/bar'>Foo</a></h1> ]]>"}))))
 
@@ -64,7 +64,7 @@
                          {:foo "Foo"}))))
 
 (deftest validation-off
-  (is (= "<?xml version='1.0' encoding='UTF-8'?>\n<rss version='2.0' xmlns:atom='http://www.w3.org/2005/Atom'>\n<channel>\n<atom:link href='http://foo/bar' rel='self' type='application/rss+xml'/>\n<title>\nFoo\n</title>\n<description>\nFoo\n</description>\n<link>\nhttp://foo/bar\n</link>\n<generator>\nclj-rss\n</generator>\n<item>\n<foo>\nFoo\n</foo>\n</item>\n</channel>\n</rss>\n"
+  (is (= "<?xml version='1.0' encoding='UTF-8'?><rss version='2.0' xmlns:atom='http://www.w3.org/2005/Atom'><channel><atom:link href='http://foo/bar' rel='self' type='application/rss+xml'/><title>Foo</title><description>Foo</description><link>http://foo/bar</link><generator>clj-rss</generator><item><foo>Foo</foo></item></channel></rss>"
          (channel-xml false
                       {:title "Foo" :description "Foo" :link "http://foo/bar"}
                       {:foo "Foo"}))))

--- a/test/clj_rss/core_test.clj
+++ b/test/clj_rss/core_test.clj
@@ -5,7 +5,7 @@
 
 (deftest proper-message
   (is
-   (= "<?xml version='1.0' encoding='UTF-8'?>\n<rss version='2.0' xmlns:atom='http://www.w3.org/2005/Atom'>\n<channel>\n<atom:link href='http://foo/bar' rel='self' type='application/rss+xml'/>\n<generator>\nclj-rss\n</generator>\n<description>\nsome channel\n</description>\n<title>\nFoo\n</title>\n<link>\nhttp://foo/bar\n</link>\n<item>\n<title>\nFoo\n</title>\n</item>\n<item>\n<title>\npost\n</title>\n<author>\nYogthos\n</author>\n</item>\n<item>\n<description>\nbar\n</description>\n</item>\n</channel>\n</rss>\n"
+   (= "<?xml version='1.0' encoding='UTF-8'?>\n<rss version='2.0' xmlns:atom='http://www.w3.org/2005/Atom'>\n<channel>\n<atom:link href='http://foo/bar' rel='self' type='application/rss+xml'/>\n<title>\nFoo\n</title>\n<link>\nhttp://foo/bar\n</link>\n<description>\nsome channel\n</description>\n<generator>\nclj-rss\n</generator>\n<item>\n<title>\nFoo\n</title>\n</item>\n<item>\n<title>\npost\n</title>\n<author>\nYogthos\n</author>\n</item>\n<item>\n<description>\nbar\n</description>\n</item>\n</channel>\n</rss>\n"
       (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel"}
                    {:title "Foo"}
                    {:title "post" :author "Yogthos"}
@@ -46,13 +46,13 @@
                          {:link "http://foo"}))))
 
 (deftest complex-tag
-  (is (= "<?xml version='1.0' encoding='UTF-8'?>\n<rss version='2.0' xmlns:atom='http://www.w3.org/2005/Atom'>\n<channel>\n<atom:link href='http://foo/bar' rel='self' type='application/rss+xml'/>\n<generator>\nclj-rss\n</generator>\n<description>\nsome channel\n</description>\n<title>\nFoo\n</title>\n<link>\nhttp://foo/bar\n</link>\n<item>\n<category domain='http://www.fool.com/cusips'>\nMSFT\n</category>\n<title>\ntest\n</title>\n</item>\n</channel>\n</rss>\n"
+  (is (= "<?xml version='1.0' encoding='UTF-8'?>\n<rss version='2.0' xmlns:atom='http://www.w3.org/2005/Atom'>\n<channel>\n<atom:link href='http://foo/bar' rel='self' type='application/rss+xml'/>\n<title>\nFoo\n</title>\n<link>\nhttp://foo/bar\n</link>\n<description>\nsome channel\n</description>\n<generator>\nclj-rss\n</generator>\n<item>\n<title>\ntest\n</title>\n<category domain='http://www.fool.com/cusips'>\nMSFT\n</category>\n</item>\n</channel>\n</rss>\n"
          (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel"}
                       {:title "test"
                        :category [{:domain "http://www.fool.com/cusips"} "MSFT"]}))))
 
 (deftest cdata-tag
-  (is (= "<?xml version='1.0' encoding='UTF-8'?>\n<rss version='2.0' xmlns:atom='http://www.w3.org/2005/Atom'>\n<channel>\n<atom:link href='http://foo/bar' rel='self' type='application/rss+xml'/>\n<generator>\nclj-rss\n</generator>\n<description>\nsome channel\n</description>\n<title>\nFoo\n</title>\n<link>\nhttp://foo/bar\n</link>\n<item>\n<description>\n<![CDATA[ <h1><a href='http://foo/bar'>Foo</a></h1> ]]>\n</description>\n<title>\nHTML Item\n</title>\n</item>\n</channel>\n</rss>\n"
+  (is (= "<?xml version='1.0' encoding='UTF-8'?>\n<rss version='2.0' xmlns:atom='http://www.w3.org/2005/Atom'>\n<channel>\n<atom:link href='http://foo/bar' rel='self' type='application/rss+xml'/>\n<title>\nFoo\n</title>\n<link>\nhttp://foo/bar\n</link>\n<description>\nsome channel\n</description>\n<generator>\nclj-rss\n</generator>\n<item>\n<title>\nHTML Item\n</title>\n<description>\n<![CDATA[ <h1><a href='http://foo/bar'>Foo</a></h1> ]]>\n</description>\n</item>\n</channel>\n</rss>\n"
          (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel"}
                       {:title "HTML Item" :description "<![CDATA[ <h1><a href='http://foo/bar'>Foo</a></h1> ]]>"}))))
 
@@ -64,7 +64,7 @@
                          {:foo "Foo"}))))
 
 (deftest validation-off
-  (is (= "<?xml version='1.0' encoding='UTF-8'?>\n<rss version='2.0' xmlns:atom='http://www.w3.org/2005/Atom'>\n<channel>\n<atom:link href='http://foo/bar' rel='self' type='application/rss+xml'/>\n<generator>\nclj-rss\n</generator>\n<description>\nFoo\n</description>\n<title>\nFoo\n</title>\n<link>\nhttp://foo/bar\n</link>\n<item>\n<foo>\nFoo\n</foo>\n</item>\n</channel>\n</rss>\n"
+  (is (= "<?xml version='1.0' encoding='UTF-8'?>\n<rss version='2.0' xmlns:atom='http://www.w3.org/2005/Atom'>\n<channel>\n<atom:link href='http://foo/bar' rel='self' type='application/rss+xml'/>\n<title>\nFoo\n</title>\n<description>\nFoo\n</description>\n<link>\nhttp://foo/bar\n</link>\n<generator>\nclj-rss\n</generator>\n<item>\n<foo>\nFoo\n</foo>\n</item>\n</channel>\n</rss>\n"
          (channel-xml false
                       {:title "Foo" :description "Foo" :link "http://foo/bar"}
                       {:foo "Foo"}))))

--- a/test/clj_rss/core_test.clj
+++ b/test/clj_rss/core_test.clj
@@ -5,7 +5,7 @@
 
 (deftest proper-message
   (is
-   (= "<?xml version='1.0' encoding='UTF-8'?><rss version='2.0' xmlns:atom='http://www.w3.org/2005/Atom'><channel><atom:link href='http://foo/bar' rel='self' type='application/rss+xml'/><title>Foo</title><link>http://foo/bar</link><description>some channel</description><generator>clj-rss</generator><item><title>Foo</title></item><item><title>post</title><author>Yogthos</author></item><item><description>bar</description></item></channel></rss>"
+   (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"/><title>Foo</title><link>http://foo/bar</link><description>some channel</description><generator>clj-rss</generator><item><title>Foo</title></item><item><title>post</title><author>Yogthos</author></item><item><description>bar</description></item></channel></rss>"
       (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel"}
                    {:title "Foo"}
                    {:title "post" :author "Yogthos"}
@@ -46,15 +46,15 @@
                          {:link "http://foo"}))))
 
 (deftest complex-tag
-  (is (= "<?xml version='1.0' encoding='UTF-8'?><rss version='2.0' xmlns:atom='http://www.w3.org/2005/Atom'><channel><atom:link href='http://foo/bar' rel='self' type='application/rss+xml'/><title>Foo</title><link>http://foo/bar</link><description>some channel</description><generator>clj-rss</generator><item><title>test</title><category domain='http://www.fool.com/cusips'>MSFT</category></item></channel></rss>"
+  (is (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"/><title>Foo</title><link>http://foo/bar</link><description>some channel</description><generator>clj-rss</generator><item><title>test</title><category domain=\"http://www.fool.com/cusips\">MSFT</category></item></channel></rss>"
          (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel"}
                       {:title "test"
                        :category [{:domain "http://www.fool.com/cusips"} "MSFT"]}))))
 
 (deftest cdata-tag
-  (is (= "<?xml version='1.0' encoding='UTF-8'?><rss version='2.0' xmlns:atom='http://www.w3.org/2005/Atom'><channel><atom:link href='http://foo/bar' rel='self' type='application/rss+xml'/><title>Foo</title><link>http://foo/bar</link><description>some channel</description><generator>clj-rss</generator><item><title>HTML Item</title><description><![CDATA[ <h1><a href='http://foo/bar'>Foo</a></h1> ]]></description></item></channel></rss>"
+  (is (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"/><title>Foo</title><link>http://foo/bar</link><description>some channel</description><generator>clj-rss</generator><item><title>HTML Item</title><description><![CDATA[ <h1><a href=\"http://foo/bar\">Foo</a></h1> ]]></description></item></channel></rss>"
          (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel"}
-                      {:title "HTML Item" :description "<![CDATA[ <h1><a href='http://foo/bar'>Foo</a></h1> ]]>"}))))
+                      {:title "HTML Item" :description "<![CDATA[ <h1><a href=\"http://foo/bar\">Foo</a></h1> ]]>"}))))
 
 (deftest validation-on
   (is
@@ -64,7 +64,7 @@
                          {:foo "Foo"}))))
 
 (deftest validation-off
-  (is (= "<?xml version='1.0' encoding='UTF-8'?><rss version='2.0' xmlns:atom='http://www.w3.org/2005/Atom'><channel><atom:link href='http://foo/bar' rel='self' type='application/rss+xml'/><title>Foo</title><description>Foo</description><link>http://foo/bar</link><generator>clj-rss</generator><item><foo>Foo</foo></item></channel></rss>"
+  (is (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"/><title>Foo</title><description>Foo</description><link>http://foo/bar</link><generator>clj-rss</generator><item><foo>Foo</foo></item></channel></rss>"
          (channel-xml false
                       {:title "Foo" :description "Foo" :link "http://foo/bar"}
                       {:foo "Foo"}))))


### PR DESCRIPTION
This is a fix for #15, which although previously closed I believe to be a real and solvable issue. I've just started using Cryogen and hoping to bubble this up to get the RSS feeds to work properly. Thanks for your time, let me know what else I can do to help.

### Why it's needed:
Newlines within a tag that contains a string value means the string starts and ends with a newline. This can cause issues, for example some RSS reeders may only take the first line of a title and so the title will appear blank in the feed.

### Some context:
The discussion in the issue points to the [implementation in data.xml/emit](https://github.com/clojure/data.xml/blob/c541be3517ecd5d0761847ac6bd585c92c5d34ed/src/main/clojure/clojure/data/xml/jvm/emit.clj), but the code actually uses [this method in clojure.xml](https://github.com/clojure/clojure/blob/b9b1a094499b69a94bd47fc94c4f082d80239fa9/src/clj/clojure/xml.clj#L111). The latter appears to be more of a handy debugging tool than a fully-fledged feature, due to its lack of documenation and its use of `print` and `println`. In fact, data.xml explicitely doesn't add any newlines in the markup except via the `indent-str` function, which is specifically designed for debugging purposes.

### Proposed solution:
Use data.xml to output the xml. `0.2.0` supports the same map format currently used, making the transition fairly painless.

Required changes:
* Clojure 1.7+ (updated the project to 1.10 to be able to use nrepl)
* Rather than escape strings manually, remove CDATA tags and wrap using the `cdata` function. This is because data.xml handles escaping strings for us.
* This does mean that single quotes have been replaced with double quotes, but that seems fine/standard.
* The order of the fields has changed slightly so needed to update the tests accordingly. It's now the same as specified in the map literal in the tests (true since Clojure 1.7 as well, I think because of use of ArrayMap behind the scenes).

### Possible Alternative:
Implement a custom `emit` function, which is just a copy of the original but with `print` instead of `println`. This keeps the scope of the change to a minimum and keeps the use of single quotes within tags. Possibly less future-proof and more fragile though. See second commit a9b6405.