### PR TITLE
Content:encoded tag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Leiningen
 The `channel-xml` function accepts a map of tags representing a channel, followed by 0 or more maps for items (or a seq of items) and outputs an XML string.
 Each item must be a map of valid RSS tags.
 
-The following characters in the content of :description and :title tags will be escaped: `<`, `&`, `>`, `"`. Both `:pubDate` and `:lastBuildDate` keys are expected to be instances of `java.util.Date`
-or one of its subclasses. These will be converted to standard RSS date strings in the resulting XML.
+The following characters in the content of :description, "content:encoded" and :title tags will be escaped: `<`, `&`, `>`, `"`. Both `:pubDate` and `:lastBuildDate` keys are expected to be instances
+of `java.util.Date` or one of its subclasses. These will be converted to standard RSS date strings in the resulting XML.
 
 If you need to get the data in a structured format, use `channel` instead.
 
@@ -31,7 +31,8 @@ Creating a channel with some items:
 (rss/channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel"}
                  {:title "Foo"}
                  {:title "post" :author "author@foo.bar"}
-                 {:description "bar"})
+                 {:description "bar"}
+                 {:description "baz" "content:encoded" "Full content"})
 ```
 
 image tags can be inserted by providing the `:type` key:
@@ -70,7 +71,8 @@ Creating items with complex tags:
 Items can contain raw HTML if the tag is enclosed in `<![CDATA[ ... ]]>`:
 ```clojure
   {:title "HTML Item"
-   :description "<![CDATA[ <h1><a href='http://foo/bar'>Foo</a></h1> ]]>"}
+   :description "<![CDATA[ <h1><a href='http://foo/bar'>Foo</a></h1> ]]>"
+   "content:encoded" "<![CDATA[ <article><h1>Title</h1><p>Hello World</p></article> ]]>"}
 ```
 
 To get the raw data structure use:

--- a/src/clj_rss/core.clj
+++ b/src/clj_rss/core.clj
@@ -71,30 +71,35 @@
 (defn- validate-item [tags]
   (when (not (or (:title tags) (:image tags) (:description tags)))
     (throw (new Exception (str "item " tags " must contain one of title or description!"))))
-  (validate-tags (keys tags) #{:type :image :url :title :link :description :author :category :comments :enclosure :guid :pubDate :source}))
+  (when (and (get tags "content:encoded") (not (:description tags)))
+    (throw (new Exception (str "item " tags " must contain a description since it contains a content:enclosed!"))))
+  (validate-tags (keys tags) #{:type :image :url :title :link :description "content:encoded" :author :category :comments :enclosure :guid :pubDate :source}))
 
 
 
 (defn- make-tags [tags]
   (flatten
-    (for [[k v] (seq tags)]
-      (cond
-        (and (coll? v) (map? (first v)))
-        (apply-macro clj-rss.core/tag (into [k] v))
-        (coll? v)
-        (map (fn [v] (make-tags {k v})) v)
-        :else
-        (tag k (cond
-                 (some #{k} [:pubDate :lastBuildDate]) (format-time v)
-                 (some #{k} [:description :title :link :author]) (xml-str v)
-                 :else v))))))
+   (for [[k v] (seq tags)]
+     (cond
+       (and (coll? v) (map? (first v)))
+       (apply-macro clj-rss.core/tag (into [k] v))
+       (coll? v)
+       (map (fn [v] (make-tags {k v})) v)
+       :else
+       (tag k (cond
+                (some #{k} [:pubDate :lastBuildDate]) (format-time v)
+                (some #{k} [:description :title :link :author "content:encoded"]) (xml-str v)
+                :else v))))))
 
 
 (defn- item [validate? tags]
   (when validate? (validate-item (dissoc-nil tags)))
-  {:tag (or (:type tags) :item)
-   :attrs nil
-   :content (make-tags (dissoc-nil (dissoc tags :type)))})
+  (let [;;"content:encoded" must come after "description"
+        content (get tags "content:encoded")
+        ordered (-> tags (dissoc "content:encoded") (assoc "content:encoded" content))]
+    {:tag (or (:type tags) :item)
+     :attrs nil
+     :content (make-tags (dissoc-nil (dissoc ordered :type)))}))
 
 (defn- channel'
   "channel accepts a map of tags followed by 0 or more items

--- a/src/clj_rss/core.clj
+++ b/src/clj_rss/core.clj
@@ -1,8 +1,8 @@
 (ns clj-rss.core
   (:require
-    [clojure.data.xml :refer [emit-str cdata]]
-    [clojure.set :refer [difference]]
-    [clojure.string :refer [join]])
+   [clojure.data.xml :refer [emit-str cdata]]
+   [clojure.set :refer [difference]]
+   [clojure.string :refer [join]])
   (:import java.util.Locale
            java.text.SimpleDateFormat))
 
@@ -122,20 +122,21 @@
   (when validate? (validate-channel tags :title :link :description))
   {:tag   :rss
    :attrs {:version     "2.0"
-           "xmlns:atom" "http://www.w3.org/2005/Atom"}
+           "xmlns:atom" "http://www.w3.org/2005/Atom"
+           "xmlns:content""http://purl.org/rss/1.0/modules/content/"}
    :content
-          [{:tag     :channel
-            :attrs   nil
-            :content (concat
-                       [{:tag   "atom:link"
-                         :attrs {:href (:link tags)
-                                 :rel  "self"
-                                 :type "application/rss+xml"}}]
-                       (make-tags (conj tags {:generator "clj-rss"}))
-                       (->> items
-                            flatten
-                            (map dissoc-nil)
-                            (map (partial item validate?))))}]})
+   [{:tag     :channel
+     :attrs   nil
+     :content (concat
+               [{:tag   "atom:link"
+                 :attrs {:href (:link tags)
+                         :rel  "self"
+                         :type "application/rss+xml"}}]
+               (make-tags (conj tags {:generator "clj-rss"}))
+               (->> items
+                    flatten
+                    (map dissoc-nil)
+                    (map (partial item validate?))))}]})
 
 (defn channel [& content]
   (cond

--- a/test/clj_rss/core_test.clj
+++ b/test/clj_rss/core_test.clj
@@ -108,3 +108,15 @@
   (is (= {:title "Foo" :description "Bar"}
          (dissoc-nil {:title "Foo" :description "Bar"
                       :link  nil :category nil}))))
+
+(deftest content-encoded-comes-after-description
+  (is (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"/><title>Foo</title><link>http://foo/bar</link><description>some channel</description><generator>clj-rss</generator><item><title>test</title><description>short</description><content:encoded>LONG CONTENT</content:encoded></item></channel></rss>"
+         (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel"}
+                      {:title "test" :description "short" "content:encoded" "LONG CONTENT"})
+         (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel"}
+                      {:title "test" "content:encoded" "LONG CONTENT" :description "short"}))))
+
+(deftest missing-description-when-content-given
+  (is (thrown? Exception
+               (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel"}
+                            {:title "test" "content:encoded" "LONG CONTENT"}))))

--- a/test/clj_rss/core_test.clj
+++ b/test/clj_rss/core_test.clj
@@ -5,7 +5,7 @@
 
 (deftest proper-message
   (is
-    (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"/><title>Foo</title><link>http://foo/bar</link><description>some channel</description><generator>clj-rss</generator><item><title>Foo</title></item><item><title>post</title><author>Yogthos</author></item><item><description>bar</description></item></channel></rss>"
+   (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"/><title>Foo</title><link>http://foo/bar</link><description>some channel</description><generator>clj-rss</generator><item><title>Foo</title></item><item><title>post</title><author>Yogthos</author></item><item><description>bar</description></item></channel></rss>"
        (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel"}
                     {:title "Foo"}
                     {:title "post" :author "Yogthos"}
@@ -22,37 +22,37 @@
 
 (deftest escaping-test
   (is (=
-        {:tag     :rss,
-         :attrs   {:version "2.0", "xmlns:atom" "http://www.w3.org/2005/Atom"},
-         :content [{:tag     :channel,
-                    :attrs   nil,
-                    :content [{:tag "atom:link", :attrs {:href "http://foo", :rel "self", :type "application/rss+xml"}}
-                              {:content ["foo"], :attrs nil, :tag :title}
-                              {:content ["http://foo"], :attrs nil, :tag :link}
-                              {:content ["bar"], :attrs nil, :tag :description}
-                              {:content ["clj-rss"], :attrs nil, :tag :generator}
-                              {:tag     :image,
-                               :attrs   nil,
-                               :content [{:content [#clojure.data.xml.node.CData{:content " title "}], :attrs nil, :tag :title}
-                                         {:content ["<![CDATA[ url ]]>"], :attrs nil, :tag :url}
-                                         {:content [#clojure.data.xml.node.CData{:content " link "}], :attrs nil, :tag :link}]}]}]}
+       {:tag     :rss,
+        :attrs   {:version "2.0", "xmlns:atom" "http://www.w3.org/2005/Atom", "xmlns:content""http://purl.org/rss/1.0/modules/content/"},
+        :content [{:tag     :channel,
+                   :attrs   nil,
+                   :content [{:tag "atom:link", :attrs {:href "http://foo", :rel "self", :type "application/rss+xml"}}
+                             {:content ["foo"], :attrs nil, :tag :title}
+                             {:content ["http://foo"], :attrs nil, :tag :link}
+                             {:content ["bar"], :attrs nil, :tag :description}
+                             {:content ["clj-rss"], :attrs nil, :tag :generator}
+                             {:tag     :image,
+                              :attrs   nil,
+                              :content [{:content [#clojure.data.xml.node.CData{:content " title "}], :attrs nil, :tag :title}
+                                        {:content ["<![CDATA[ url ]]>"], :attrs nil, :tag :url}
+                                        {:content [#clojure.data.xml.node.CData{:content " link "}], :attrs nil, :tag :link}]}]}]}
 
-        (channel
-          {:title "foo" :link "http://foo" :description "bar"}
-          {:type  :image
-           :title "<![CDATA[ title ]]>"
-           :url   "<![CDATA[ url ]]>"
-           :link  "<![CDATA[ link ]]>"}))))
+       (channel
+        {:title "foo" :link "http://foo" :description "bar"}
+        {:type  :image
+         :title "<![CDATA[ title ]]>"
+         :url   "<![CDATA[ url ]]>"
+         :link  "<![CDATA[ link ]]>"}))))
 
 (deftest image-tag
   (is
-    (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\"><channel><atom:link href=\"http://x\" rel=\"self\" type=\"application/rss+xml\"/><title>Foo</title><link>http://x</link><description>some channel</description><generator>clj-rss</generator><image><title>image</title><url>http://foo.bar</url><link>http://bar.baz</link></image><item><title>foo</title><link>bar</link></item></channel></rss>"
-       (channel-xml {:title "Foo" :link "http://x" :description "some channel"}
-                    {:type  :image
-                     :title "image"
-                     :url   "http://foo.bar"
-                     :link  "http://bar.baz"}
-                    {:title "foo" :link "bar"}))))
+   (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"><channel><atom:link href=\"http://x\" rel=\"self\" type=\"application/rss+xml\"/><title>Foo</title><link>http://x</link><description>some channel</description><generator>clj-rss</generator><image><title>image</title><url>http://foo.bar</url><link>http://bar.baz</link></image><item><title>foo</title><link>bar</link></item></channel></rss>"
+      (channel-xml {:title "Foo" :link "http://x" :description "some channel"}
+                   {:type  :image
+                    :title "image"
+                    :url   "http://foo.bar"
+                    :link  "http://bar.baz"}
+                   {:title "foo" :link "bar"}))))
 
 (deftest invalid-channel-tag
   (is
@@ -81,13 +81,13 @@
                           {:link "http://foo"}))))
 
 (deftest complex-tag
-  (is (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"/><title>Foo</title><link>http://foo/bar</link><description>some channel</description><generator>clj-rss</generator><item><title>test</title><category domain=\"http://www.fool.com/cusips\">MSFT</category></item></channel></rss>"
+  (is (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"/><title>Foo</title><link>http://foo/bar</link><description>some channel</description><generator>clj-rss</generator><item><title>test</title><category domain=\"http://www.fool.com/cusips\">MSFT</category></item></channel></rss>"
          (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel"}
                       {:title    "test"
                        :category [{:domain "http://www.fool.com/cusips"} "MSFT"]}))))
 
 (deftest cdata-tag
-  (is (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"/><title>Foo</title><link>http://foo/bar</link><description>some channel</description><generator>clj-rss</generator><item><title>HTML Item</title><description><![CDATA[ <h1><a href=\"http://foo/bar\">Foo</a></h1> ]]></description></item></channel></rss>"
+  (is (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"/><title>Foo</title><link>http://foo/bar</link><description>some channel</description><generator>clj-rss</generator><item><title>HTML Item</title><description><![CDATA[ <h1><a href=\"http://foo/bar\">Foo</a></h1> ]]></description></item></channel></rss>"
          (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel"}
                       {:title "HTML Item" :description "<![CDATA[ <h1><a href=\"http://foo/bar\">Foo</a></h1> ]]>"}))))
 
@@ -99,7 +99,7 @@
                           {:foo "Foo"}))))
 
 (deftest validation-off
-  (is (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"/><title>Foo</title><description>Foo</description><link>http://foo/bar</link><generator>clj-rss</generator><item><foo>Foo</foo></item></channel></rss>"
+  (is (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"/><title>Foo</title><description>Foo</description><link>http://foo/bar</link><generator>clj-rss</generator><item><foo>Foo</foo></item></channel></rss>"
          (channel-xml false
                       {:title "Foo" :description "Foo" :link "http://foo/bar"}
                       {:foo "Foo"}))))


### PR DESCRIPTION
Added support for the 'content:encoded' xml tag as discussed in the #17 issue.
The generated XML complies with the w3 online validator.

A key "content:enclosed" can now be used in the items.
I think that keeping the key explicit (as a string, and as the standard) makes its use and meaning very clear, compared to using a :content keyword.

Let me know your opinion on this.

I will update the docs accordingly as soon as the code of the PR is reviewed and accepted :)