### PR TITLE
Refactor to use `Instant` instead of `Date` and `DateTimeFormatter` instead of `SimpleDateFormat`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The `channel-xml` function accepts a map of tags representing a channel, followe
 Each item must be a map of valid RSS tags.
 
 The following characters in the content of :description, "content:encoded" and :title tags will be escaped: `<`, `&`, `>`, `"`. Both `:pubDate` and `:lastBuildDate` keys are expected to be instances
-of `java.util.Date` or one of its subclasses. These will be converted to standard RSS date strings in the resulting XML.
+of `java.time.Instant` or one of its subclasses. These will be converted to standard RSS date strings in the resulting XML.
 
 If you need to get the data in a structured format, use `channel` instead.
 
@@ -42,7 +42,7 @@ image tags can be inserted by providing the `:type` key:
               :title "image"
               :url   "http://foo.bar"
               :link  "http://bar.baz"}
-             {:title "foo" :link "bar"}) 
+             {:title "foo" :link "bar"})
 ```
 
 Creating a feed from a sequence of items:
@@ -51,7 +51,7 @@ Creating a feed from a sequence of items:
   (rss/channel {:title "Foo" :link "http://foo/bar" :description "some channel"}
                items))
 
-;; Atom feed URL can be specified using :feed-url key: 
+;; Atom feed URL can be specified using :feed-url key:
 (rss/channel
   {:title "foo" :link "http://foo" :feed-url "http://feed-url" :description "bar"}
   {:type  :image
@@ -73,7 +73,7 @@ Creating items with complex tags:
 
 (rss/channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel"}
               {:title "test"
-              :category ["MSFT" "AAPL"]})                             
+              :category ["MSFT" "AAPL"]})
 ```
 
 Items can contain raw HTML if the tag is enclosed in `<![CDATA[ ... ]]>`:

--- a/src/clj_rss/core.clj
+++ b/src/clj_rss/core.clj
@@ -1,22 +1,15 @@
 (ns clj-rss.core
-  (:require
-   [clojure.data.xml :refer [emit-str cdata]]
-   [clojure.set :refer [difference]]
-   [clojure.string :refer [join]])
-  (:import java.util.Locale
-           java.text.SimpleDateFormat))
+  (:require [clojure.data.xml :refer [cdata emit-str]]
+            [clojure.set :refer [difference]]
+            [clojure.string :refer [join]])
+  (:import (java.time Instant ZoneOffset)
+           java.time.format.DateTimeFormatter
+           java.util.Locale))
 
-(defn- format-time [t]
-  (letfn [(fmt-t [date]
-            (.format (new SimpleDateFormat
-                          "EEE, dd MMM yyyy HH:mm:ss ZZZZ"
-                          Locale/ENGLISH) date))]
-    (when t
-      (cond
-        (instance? java.util.Date t)
-        (fmt-t t)
-        (instance? java.time.Instant t)
-        (fmt-t (java.util.Date/from t))))))
+(defn- format-time [^Instant t]
+  (when t
+    (.format (DateTimeFormatter/ofPattern "EEE, dd MMM yyyy HH:mm:ss ZZ" Locale/ENGLISH)
+             (.atOffset t ZoneOffset/UTC))))
 
 (defn- xml-str
   "Returns a value suitable for inclusion as an XML element. If the string

--- a/src/clj_rss/core.clj
+++ b/src/clj_rss/core.clj
@@ -7,8 +7,16 @@
            java.text.SimpleDateFormat))
 
 (defn- format-time [t]
-  (when t
-    (.format (new SimpleDateFormat "EEE, dd MMM yyyy HH:mm:ss ZZZZ" Locale/ENGLISH) t)))
+  (letfn [(fmt-t [date]
+            (.format (new SimpleDateFormat
+                          "EEE, dd MMM yyyy HH:mm:ss ZZZZ"
+                          Locale/ENGLISH) date))]
+    (when t
+      (cond
+        (instance? java.util.Date t)
+        (fmt-t t)
+        (instance? java.time.Instant t)
+        (fmt-t (java.util.Date/from t))))))
 
 (defn- xml-str
   "Returns a value suitable for inclusion as an XML element. If the string

--- a/test/clj_rss/core_test.clj
+++ b/test/clj_rss/core_test.clj
@@ -179,10 +179,7 @@
                (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel"}
                             {:title "test" "content:encoded" "LONG CONTENT"}))))
 
-(deftest format-time-supports-date-and-instant-objects
-  (let [inst      (java.time.Instant/now)
-        date      (java.util.Date/from inst)
-        test-date (fn [t] (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel" :lastBuildDate t}
-                                       {:title "Foo" :pubDate t}))]
-    (is (= (test-date inst)
-           (test-date date)))))
+(deftest format-time-supports-instant
+  (is (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"/><title>Foo</title><link>http://foo/bar</link><description>some channel</description><lastBuildDate>Thu, 01 Jan 1970 00:00:00 +0000</lastBuildDate><generator>clj-rss</generator><item><title>Foo</title><pubDate>Thu, 01 Jan 1970 00:00:00 +0000</pubDate></item></channel></rss>"
+         (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel" :lastBuildDate (java.time.Instant/ofEpochSecond 0)}
+                      {:title "Foo" :pubDate (java.time.Instant/ofEpochSecond 0)}))))

--- a/test/clj_rss/core_test.clj
+++ b/test/clj_rss/core_test.clj
@@ -178,3 +178,11 @@
   (is (thrown? Exception
                (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel"}
                             {:title "test" "content:encoded" "LONG CONTENT"}))))
+
+(deftest format-time-supports-date-and-instant-objects
+  (let [inst      (java.time.Instant/now)
+        date      (java.util.Date/from inst)
+        test-date (fn [t] (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel" :lastBuildDate t}
+                                       {:title "Foo" :pubDate t}))]
+    (is (= (test-date inst)
+           (test-date date)))))


### PR DESCRIPTION
I thought this might be useful, not sure how necessary this is though.
I was under the impression that java.util.Date was deprecated, but I guess I'm wrong.