### PR TITLE
Use latest stable clojure.data.xml 0.0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Leiningen
 
 [![Clojars Project](http://clojars.org/clj-rss/latest-version.svg)](http://clojars.org/clj-rss)
 
-**note**: clj-rss uses `org.clojure/data.xml` version 0.2.0-alpha6.
-
 ## Usage
 
 The `channel-xml` function accepts a map of tags representing a channel, followed by 0 or more maps for items (or a seq of items) and outputs an XML string.

--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
-(defproject clj-rss "0.3.0"
+(defproject clj-rss "0.4.0-SNAPSHOT"
   :description "A library for generating RSS feeds from Clojure."
   :url "https://github.com/yogthos/clj-rss"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [org.clojure/data.xml "0.2.0-alpha6"]]
+                 [org.clojure/data.xml "0.0.8"]]
   :profiles {:dev
              {:dependencies [[hickory "0.7.1"]]}})

--- a/test/clj_rss/core_test.clj
+++ b/test/clj_rss/core_test.clj
@@ -5,7 +5,7 @@
 
 (deftest proper-message
   (is
-    (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"/><title>Foo</title><link>http://foo/bar</link><description>some channel</description><generator>clj-rss</generator><item><title>Foo</title></item><item><title>post</title><author>Yogthos</author></item><item><description>bar</description></item></channel></rss>"
+    (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"></atom:link><title>Foo</title><link>http://foo/bar</link><description>some channel</description><generator>clj-rss</generator><item><title>Foo</title></item><item><title>post</title><author>Yogthos</author></item><item><description>bar</description></item></channel></rss>"
        (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel"}
                     {:title "Foo"}
                     {:title "post" :author "Yogthos"}
@@ -22,21 +22,31 @@
 
 (deftest escaping-test
   (is (=
-        {:tag     :rss,
-         :attrs   {:version "2.0", "xmlns:atom" "http://www.w3.org/2005/Atom", "xmlns:content" "http://purl.org/rss/1.0/modules/content/"},
-         :content [{:tag     :channel,
-                    :attrs   nil,
-                    :content [{:tag "atom:link", :attrs {:href "http://foo", :rel "self", :type "application/rss+xml"}}
-                              {:content ["foo"], :attrs nil, :tag :title}
-                              {:content ["http://foo"], :attrs nil, :tag :link}
-                              {:content ["bar"], :attrs nil, :tag :description}
-                              {:content ["clj-rss"], :attrs nil, :tag :generator}
-                              {:tag     :image,
-                               :attrs   nil,
-                               :content [{:content [#clojure.data.xml.node.CData{:content " title "}], :attrs nil, :tag :title}
-                                         {:content ["<![CDATA[ url ]]>"], :attrs nil, :tag :url}
-                                         {:content [#clojure.data.xml.node.CData{:content " link "}], :attrs nil, :tag :link}]}]}]}
-
+        #clojure.data.xml.Element
+        {:tag :rss
+         :attrs {:version "2.0"
+                 "xmlns:atom" "http://www.w3.org/2005/Atom"
+                 "xmlns:content" "http://purl.org/rss/1.0/modules/content/"}
+         :content ([#clojure.data.xml.Element
+                    {:tag :channel
+                     :attrs {}
+                     :content ((#clojure.data.xml.Element{:tag "atom:link", :attrs {:href "http://foo", :rel "self", :type "application/rss+xml"}, :content ()}
+                                #clojure.data.xml.Element{:tag :title, :attrs {}, :content (["foo"])}
+                                #clojure.data.xml.Element{:tag :link, :attrs {}, :content (["http://foo"])}
+                                #clojure.data.xml.Element{:tag :description, :attrs {}, :content (["bar"])}
+                                #clojure.data.xml.Element{:tag :generator, :attrs {}, :content (["clj-rss"])}
+                                #clojure.data.xml.Element
+                                {:tag :image
+                                 :attrs {}
+                                 :content ((#clojure.data.xml.Element{:tag :title
+                                                                      :attrs {}
+                                                                      :content ([#clojure.data.xml.CData{:content " title "}])}
+                                            #clojure.data.xml.Element{:tag :url
+                                                                      :attrs {}
+                                                                      :content (["<![CDATA[ url ]]>"])}
+                                            #clojure.data.xml.Element{:tag :link
+                                                                      :attrs {}
+                                                                      :content ([#clojure.data.xml.CData{:content " link "}])}))}))}])}
         (channel
           {:title "foo" :link "http://foo" :description "bar"}
           {:type  :image
@@ -46,7 +56,7 @@
 
 (deftest image-tag
   (is
-    (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"><channel><atom:link href=\"http://x\" rel=\"self\" type=\"application/rss+xml\"/><title>Foo</title><link>http://x</link><description>some channel</description><generator>clj-rss</generator><image><title>image</title><url>http://foo.bar</url><link>http://bar.baz</link></image><item><title>foo</title><link>bar</link></item></channel></rss>"
+    (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"><channel><atom:link href=\"http://x\" rel=\"self\" type=\"application/rss+xml\"></atom:link><title>Foo</title><link>http://x</link><description>some channel</description><generator>clj-rss</generator><image><title>image</title><url>http://foo.bar</url><link>http://bar.baz</link></image><item><title>foo</title><link>bar</link></item></channel></rss>"
        (channel-xml {:title "Foo" :link "http://x" :description "some channel"}
                     {:type  :image
                      :title "image"
@@ -57,22 +67,29 @@
 (deftest feed-url
   (is
     (=
-      {:tag     :rss
-       :attrs   {:version        "2.0"
-                 "xmlns:atom"    "http://www.w3.org/2005/Atom"
-                 "xmlns:content" "http://purl.org/rss/1.0/modules/content/"}
-       :content [{:tag     :channel
-                  :attrs   nil
-                  :content '({:tag "atom:link" :attrs {:href "http://foo" :rel "self" :type "application/rss+xml"}}
-                             {:content ["foo"] :attrs nil :tag :title}
-                             {:content ["http://foo"] :attrs nil :tag :link}
-                             {:content ["bar"] :attrs nil :tag :description}
-                             {:content ["clj-rss"] :attrs nil :tag :generator}
-                             {:tag     :image
-                              :attrs   nil
-                              :content ({:content ["Title"], :attrs nil :tag :title}
-                                        {:content ["http://bar"] :attrs nil :tag :url}
-                                        {:content ["http://baz"] :attrs nil :tag :link})})}]}
+      #clojure.data.xml.Element
+      {:tag :rss
+       :attrs {:version "2.0"
+               "xmlns:atom" "http://www.w3.org/2005/Atom"
+               "xmlns:content" "http://purl.org/rss/1.0/modules/content/"}
+       :content ([#clojure.data.xml.Element
+                  {:tag :channel
+                   :attrs {}
+                   :content ((#clojure.data.xml.Element{:tag "atom:link"
+                                                        :attrs {:href "http://foo"
+                                                                :rel "self"
+                                                                :type "application/rss+xml"}
+                                                        :content ()}
+                               #clojure.data.xml.Element{:tag :title, :attrs {}, :content (["foo"])}
+                               #clojure.data.xml.Element{:tag :link, :attrs {}, :content (["http://foo"])}
+                               #clojure.data.xml.Element{:tag :description, :attrs {}, :content (["bar"])}
+                               #clojure.data.xml.Element{:tag :generator, :attrs {}, :content (["clj-rss"])}
+                               #clojure.data.xml.Element
+                               {:tag :image
+                                :attrs {}
+                                :content ((#clojure.data.xml.Element{:tag :title, :attrs {}, :content (["Title"])}
+                                           #clojure.data.xml.Element{:tag :url, :attrs {}, :content (["http://bar"])}
+                                           #clojure.data.xml.Element{:tag :link, :attrs {}, :content (["http://baz"])}))}))}])}
       (channel
         {:title "foo" :link "http://foo" :description "bar"}
         {:type  :image
@@ -81,22 +98,34 @@
          :link  "http://baz"})))
   (is
     (=
-      {:tag     :rss
-       :attrs   {:version        "2.0"
-                 "xmlns:atom"    "http://www.w3.org/2005/Atom"
-                 "xmlns:content" "http://purl.org/rss/1.0/modules/content/"}
-       :content [{:tag     :channel
-                  :attrs   nil
-                  :content '({:tag "atom:link" :attrs {:href "http://feed-url" :rel "self" :type "application/rss+xml"}}
-                             {:content ["foo"] :attrs nil :tag :title}
-                             {:content ["http://foo"] :attrs nil :tag :link}
-                             {:content ["bar"] :attrs nil :tag :description}
-                             {:content ["clj-rss"] :attrs nil :tag :generator}
-                             {:tag     :image
-                              :attrs   nil
-                              :content ({:content ["Title"] :attrs nil :tag :title}
-                                        {:content ["http://bar"] :attrs nil :tag :url}
-                                        {:content ["http://baz"] :attrs nil :tag :link})})}]}
+      #clojure.data.xml.Element
+      {:tag :rss
+       :attrs {:version "2.0"
+               "xmlns:atom" "http://www.w3.org/2005/Atom"
+               "xmlns:content" "http://purl.org/rss/1.0/modules/content/"}
+       :content ([#clojure.data.xml.Element
+                  {:tag :channel
+                   :attrs {}
+                   :content ((#clojure.data.xml.Element{:tag "atom:link"
+                                                        :attrs {:href "http://feed-url"
+                                                                :rel "self"
+                                                                :type "application/rss+xml"}
+                                                        :content ()}
+                               #clojure.data.xml.Element{:tag :title, :attrs {}, :content (["foo"])}
+                               #clojure.data.xml.Element{:tag :link, :attrs {}, :content (["http://foo"])}
+                               #clojure.data.xml.Element{:tag :description, :attrs {}, :content (["bar"])}
+                               #clojure.data.xml.Element{:tag :generator, :attrs {}, :content (["clj-rss"])}
+                               #clojure.data.xml.Element{:tag :image
+                                                         :attrs {}
+                                                         :content ((#clojure.data.xml.Element{:tag :title
+                                                                                              :attrs {}
+                                                                                              :content (["Title"])}
+                                                                    #clojure.data.xml.Element{:tag :url
+                                                                                              :attrs {}
+                                                                                              :content (["http://bar"])}
+                                                                    #clojure.data.xml.Element{:tag :link
+                                                                                              :attrs {}
+                                                                                              :content (["http://baz"])}))}))}])}
       (channel
         {:title "foo" :link "http://foo" :feed-url "http://feed-url" :description "bar"}
         {:type  :image
@@ -133,19 +162,19 @@
 (deftest item-with-a-guid-tag
   (is
    (=
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"/><title>Foo</title><link>http://foo/bar</link><description>some channel</description><generator>clj-rss</generator><item><title>test</title><guid isPermaLink=\"false\">http://foo/bar</guid></item></channel></rss>"
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"></atom:link><title>Foo</title><link>http://foo/bar</link><description>some channel</description><generator>clj-rss</generator><item><title>test</title><guid isPermaLink=\"false\">http://foo/bar</guid></item></channel></rss>"
     (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel"}
                  {:title "test"
                   :guid "http://foo/bar"}))))
 
 (deftest complex-tag
-  (is (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"/><title>Foo</title><link>http://foo/bar</link><description>some channel</description><generator>clj-rss</generator><item><title>test</title><category domain=\"http://www.fool.com/cusips\">MSFT</category></item></channel></rss>"
+  (is (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"></atom:link><title>Foo</title><link>http://foo/bar</link><description>some channel</description><generator>clj-rss</generator><item><title>test</title><category domain=\"http://www.fool.com/cusips\">MSFT</category></item></channel></rss>"
          (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel"}
                       {:title    "test"
                        :category [{:domain "http://www.fool.com/cusips"} "MSFT"]}))))
 
 (deftest cdata-tag
-  (is (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"/><title>Foo</title><link>http://foo/bar</link><description>some channel</description><generator>clj-rss</generator><item><title>HTML Item</title><description><![CDATA[ <h1><a href=\"http://foo/bar\">Foo</a></h1> ]]></description></item></channel></rss>"
+  (is (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"></atom:link><title>Foo</title><link>http://foo/bar</link><description>some channel</description><generator>clj-rss</generator><item><title>HTML Item</title><description><![CDATA[ <h1><a href=\"http://foo/bar\">Foo</a></h1> ]]></description></item></channel></rss>"
          (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel"}
                       {:title "HTML Item" :description "<![CDATA[ <h1><a href=\"http://foo/bar\">Foo</a></h1> ]]>"}))))
 
@@ -157,7 +186,7 @@
                           {:foo "Foo"}))))
 
 (deftest validation-off
-  (is (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"/><title>Foo</title><description>Foo</description><link>http://foo/bar</link><generator>clj-rss</generator><item><foo>Foo</foo></item></channel></rss>"
+  (is (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"></atom:link><title>Foo</title><description>Foo</description><link>http://foo/bar</link><generator>clj-rss</generator><item><foo>Foo</foo></item></channel></rss>"
          (channel-xml false
                       {:title "Foo" :description "Foo" :link "http://foo/bar"}
                       {:foo "Foo"}))))
@@ -168,7 +197,7 @@
                       :link  nil :category nil}))))
 
 (deftest content-encoded-comes-after-description
-  (is (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"/><title>Foo</title><link>http://foo/bar</link><description>some channel</description><generator>clj-rss</generator><item><title>test</title><description>short</description><content:encoded>LONG CONTENT</content:encoded></item></channel></rss>"
+  (is (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"></atom:link><title>Foo</title><link>http://foo/bar</link><description>some channel</description><generator>clj-rss</generator><item><title>test</title><description>short</description><content:encoded>LONG CONTENT</content:encoded></item></channel></rss>"
          (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel"}
                       {:title "test" :description "short" "content:encoded" "LONG CONTENT"})
          (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel"}
@@ -180,6 +209,6 @@
                             {:title "test" "content:encoded" "LONG CONTENT"}))))
 
 (deftest format-time-supports-instant
-  (is (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"/><title>Foo</title><link>http://foo/bar</link><description>some channel</description><lastBuildDate>Thu, 01 Jan 1970 00:00:00 +0000</lastBuildDate><generator>clj-rss</generator><item><title>Foo</title><pubDate>Thu, 01 Jan 1970 00:00:00 +0000</pubDate></item></channel></rss>"
+  (is (= "<?xml version=\"1.0\" encoding=\"UTF-8\"?><rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\" xmlns:content=\"http://purl.org/rss/1.0/modules/content/\"><channel><atom:link href=\"http://foo/bar\" rel=\"self\" type=\"application/rss+xml\"></atom:link><title>Foo</title><link>http://foo/bar</link><description>some channel</description><lastBuildDate>Thu, 01 Jan 1970 00:00:00 +0000</lastBuildDate><generator>clj-rss</generator><item><title>Foo</title><pubDate>Thu, 01 Jan 1970 00:00:00 +0000</pubDate></item></channel></rss>"
          (channel-xml {:title "Foo" :link "http://foo/bar" :description "some channel" :lastBuildDate (java.time.Instant/ofEpochSecond 0)}
                       {:title "Foo" :pubDate (java.time.Instant/ofEpochSecond 0)}))))


### PR DESCRIPTION
Hi, long-time fan and user of your OSS work here :)

The only necessary change was to use the `clojure.data.xml/element` function rather than plain maps.

The changes to the XML string asserts in the tests are due to clojure.data.xml 0.0.8 handling of content-less elements: it emits `<atom:link></atom:link>` instead of `<atom:link/>`.

Fixes #20